### PR TITLE
Fix build failing on macOS GitHub action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
+    container: swift:latest
     steps:
     - uses: actions/checkout@v2
     - name: Resolve dependencies
@@ -17,4 +18,3 @@ jobs:
       run: swift build -v
     - name: Run tests
       run: swift test -v
-      

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container: swift:latest
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
     - name: Resolve dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Resolve dependencies
       run: swift package resolve
     - name: Build
-      run: swift build -v --enable-test-discovery
+      run: swift build -v
     - name: Run tests
-      run: swift test -v --enable-test-discovery
+      run: swift test -v
       

--- a/Sources/SCTE35Parser/SpliceInfoSection.swift
+++ b/Sources/SCTE35Parser/SpliceInfoSection.swift
@@ -304,8 +304,8 @@ public extension SpliceInfoSection {
             self.CRC_32 = bitReader.uint32(fromBits: 32)
             self.nonFatalErrors = bitReader.nonFatalErrors
         } catch {
-            guard let error = error as? ParserError else { throw error }
-            throw SCTE35ParserError(error: error, underlyingError: bitReader.nonFatalErrors.first)
+            guard let parserError = error as? ParserError else { throw error }
+            throw SCTE35ParserError(error: parserError, underlyingError: bitReader.nonFatalErrors.first)
         }
     }
 }


### PR DESCRIPTION
While using this parser in a separate project that uses macOS on GitHub Actions, the build failed as the version of Swift on that machine did not deal well with the shadowed `guard let error` declaration in `SpliceInfoSection.swift`, and so this change should address this an hopefully all will build fine now.