### PR TITLE
Arithmetic safety

### DIFF
--- a/Sources/SCTE35Parser/SpliceDescriptors/AudioDescriptor.swift
+++ b/Sources/SCTE35Parser/SpliceDescriptors/AudioDescriptor.swift
@@ -135,7 +135,7 @@ extension AudioDescriptor {
     init(bitReader: DataBitReader) throws {
         let descriptorLength = bitReader.byte()
         let bitsReadBeforeDescriptor = bitReader.bitsRead
-        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + Int(descriptorLength * 8)
+        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + (Int(descriptorLength) * 8)
         self.identifier = bitReader.uint32(fromBits: 32)
         let audioCount = bitReader.byte(fromBits: 4)
         _ = bitReader.bits(count: 4)
@@ -144,7 +144,7 @@ extension AudioDescriptor {
             bitReader.nonFatalErrors.append(
                 .unexpectedSpliceDescriptorLength(
                     UnexpectedSpliceDescriptorLengthErrorInfo(
-                        declaredSpliceDescriptorLengthInBits: Int(descriptorLength * 8),
+                        declaredSpliceDescriptorLengthInBits: (Int(descriptorLength) * 8),
                         actualSpliceDescriptorLengthInBits: bitReader.bitsRead - bitsReadBeforeDescriptor,
                         spliceDescriptorTag: .audioDescriptor
                     )

--- a/Sources/SCTE35Parser/SpliceDescriptors/AvailDescriptor.swift
+++ b/Sources/SCTE35Parser/SpliceDescriptors/AvailDescriptor.swift
@@ -47,14 +47,14 @@ extension AvailDescriptor {
     init(bitReader: DataBitReader) throws {
         let descriptorLength = bitReader.byte()
         let bitsReadBeforeDescriptor = bitReader.bitsRead
-        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + Int(descriptorLength * 8)
+        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + (Int(descriptorLength) * 8)
         self.identifier = bitReader.uint32(fromBits: 32)
         self.providerAvailId = bitReader.uint32(fromBits: 32)
         if bitReader.bitsRead != expectedBitsReadAtEndOfDescriptor {
             bitReader.nonFatalErrors.append(
                 .unexpectedSpliceDescriptorLength(
                     UnexpectedSpliceDescriptorLengthErrorInfo(
-                        declaredSpliceDescriptorLengthInBits: Int(descriptorLength * 8),
+                        declaredSpliceDescriptorLengthInBits: (Int(descriptorLength) * 8),
                         actualSpliceDescriptorLengthInBits: bitReader.bitsRead - bitsReadBeforeDescriptor,
                         spliceDescriptorTag: .availDescriptor
                     )

--- a/Sources/SCTE35Parser/SpliceDescriptors/DTMFDescriptor.swift
+++ b/Sources/SCTE35Parser/SpliceDescriptors/DTMFDescriptor.swift
@@ -55,7 +55,7 @@ extension DTMFDescriptor {
     init(bitReader: DataBitReader) throws {
         let descriptorLength = bitReader.byte()
         let bitsReadBeforeDescriptor = bitReader.bitsRead
-        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + Int(descriptorLength * 8)
+        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + (Int(descriptorLength) * 8)
         self.identifier = bitReader.uint32(fromBits: 32)
         self.preroll = bitReader.byte()
         let dtmfCount = bitReader.byte(fromBits: 3)
@@ -65,7 +65,7 @@ extension DTMFDescriptor {
             bitReader.nonFatalErrors.append(
                 .unexpectedSpliceDescriptorLength(
                     UnexpectedSpliceDescriptorLengthErrorInfo(
-                        declaredSpliceDescriptorLengthInBits: Int(descriptorLength * 8),
+                        declaredSpliceDescriptorLengthInBits: (Int(descriptorLength) * 8),
                         actualSpliceDescriptorLengthInBits: bitReader.bitsRead - bitsReadBeforeDescriptor,
                         spliceDescriptorTag: .dtmfDescriptor
                     )

--- a/Sources/SCTE35Parser/SpliceDescriptors/SegmentationDescriptor+SegmentationUPID.swift
+++ b/Sources/SCTE35Parser/SpliceDescriptors/SegmentationDescriptor+SegmentationUPID.swift
@@ -170,7 +170,7 @@ extension SegmentationDescriptor.SegmentationUPID {
         case .mpu:
             self = try .mpu(SegmentationDescriptor.ManagedPrivateUPID(bitReader: bitReader, upidLength: upidLength))
         case .mid:
-            let bitsLeftAfterUPID = bitReader.bitsLeft - Int(upidLength * 8)
+            let bitsLeftAfterUPID = bitReader.bitsLeft - (Int(upidLength) * 8)
             var mid = [SegmentationDescriptor.SegmentationUPID]()
             while bitReader.bitsLeft > bitsLeftAfterUPID {
                 try mid.append(SegmentationDescriptor.SegmentationUPID(bitReader: bitReader))

--- a/Sources/SCTE35Parser/SpliceDescriptors/SegmentationDescriptor.swift
+++ b/Sources/SCTE35Parser/SpliceDescriptors/SegmentationDescriptor.swift
@@ -268,7 +268,7 @@ extension SegmentationDescriptor {
             bitReader.nonFatalErrors.append(
                 .unexpectedSpliceDescriptorLength(
                     UnexpectedSpliceDescriptorLengthErrorInfo(
-                        declaredSpliceDescriptorLengthInBits: Int(descriptorLength * 8),
+                        declaredSpliceDescriptorLengthInBits: descriptorLength * 8,
                         actualSpliceDescriptorLengthInBits: bitReader.bitsRead - bitsReadBeforeDescriptor,
                         spliceDescriptorTag: .segmentationDescriptor
                     )

--- a/Sources/SCTE35Parser/SpliceDescriptors/TimeDescriptor.swift
+++ b/Sources/SCTE35Parser/SpliceDescriptors/TimeDescriptor.swift
@@ -78,7 +78,7 @@ extension TimeDescriptor {
     init(bitReader: DataBitReader) throws {
         let descriptorLength = bitReader.byte()
         let bitsReadBeforeDescriptor = bitReader.bitsRead
-        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + Int(descriptorLength * 8)
+        let expectedBitsReadAtEndOfDescriptor = bitReader.bitsRead + (Int(descriptorLength) * 8)
         self.identifier = bitReader.uint32(fromBits: 32)
         self.taiSeconds = bitReader.uint64(fromBits: 48)
         self.taiNS = bitReader.uint32(fromBits: 32)
@@ -87,7 +87,7 @@ extension TimeDescriptor {
             bitReader.nonFatalErrors.append(
                 .unexpectedSpliceDescriptorLength(
                     UnexpectedSpliceDescriptorLengthErrorInfo(
-                        declaredSpliceDescriptorLengthInBits: Int(descriptorLength * 8),
+                        declaredSpliceDescriptorLengthInBits: (Int(descriptorLength) * 8),
                         actualSpliceDescriptorLengthInBits: bitReader.bitsRead - bitsReadBeforeDescriptor,
                         spliceDescriptorTag: .timeDescriptor
                     )

--- a/Tests/SCTE35ParserTests/SCTE35ParserTests.swift
+++ b/Tests/SCTE35ParserTests/SCTE35ParserTests.swift
@@ -1341,4 +1341,48 @@ final class SCTE35ParserTests: XCTestCase {
         )
         try XCTAssertEqual(expectedSpliceInfoSection, SpliceInfoSection(hexString))
     }
+    
+    // MARK: - Further examples
+    
+    func test_timeSignal_segmentationDescriptor_mid() {
+        let base64String = "/DBwAAAAAAAAAP/wBQb/AAAAAABaAlhDVUVJAAAAAn//AABSZcANRAoMFHeL5eP2AAAAAAAACgwUd4vl4/YAAAAAAAAJJlNJR05BTDpMeTlFTUd4S1IwaEZaVXRwTUhkQ1VWWm5SVUZuWnowNgEB1Dao2g=="
+        let expectedSpliceInfoSection = SpliceInfoSection(
+            tableID: 252,
+            sapType: .unspecified,
+            protocolVersion: 0,
+            encryptedPacket: nil,
+            ptsAdjustment: 0,
+            tier: 0xFFF,
+            spliceCommand: .timeSignal(TimeSignal(spliceTime: SpliceTime(ptsTime: 4294967296))),
+            spliceDescriptors: [
+                .segmentationDescriptor(
+                    SegmentationDescriptor(
+                        identifier: 1129661769,
+                        eventId: 2,
+                        scheduledEvent: SegmentationDescriptor.ScheduledEvent(
+                            deliveryRestrictions: nil,
+                            componentSegments: nil,
+                            segmentationDuration: 5400000,
+                            segmentationUPID: .mid(
+                                [
+                                    // TODO - EIDR DOI suffix is not always ISAN, as demonstrated here.
+                                    // It may be worth creating a struct for the EIDR so as not to force
+                                    // an unexpected format (the below examples should be "10.5239/8BE5-E3F6").
+                                    .eidr("10.5239/8BE5-E3F6-0000-0000-0000-B"),
+                                    .eidr("10.5239/8BE5-E3F6-0000-0000-0000-B"),
+                                    .adi("SIGNAL:Ly9EMGxKR0hFZUtpMHdCUVZnRUFnZz0")
+                                ]
+                            ),
+                            segmentationTypeID: .distributorPlacementOpportunityStart,
+                            segmentNum: 1,
+                            segmentsExpected: 1,
+                            subSegment: nil
+                        )
+                    )
+                )
+            ],
+            CRC_32: 0xD436A8DA
+        )
+        try XCTAssertEqual(expectedSpliceInfoSection, SpliceInfoSection(base64String))
+    }
 }


### PR DESCRIPTION
Quite embarrassingly, I accidentally was multiplying `UInt8` numbers and then converting to Int, rather than converting to `Int` and then multiplying. This revealed itself as an arithmetic overflow in the parsing of a SCTE-35 splice info section which has now been added to the known test-cases.

This change makes sure that all locations where we do multiplication is now converted to Int first. I also made a check for addition to be safe.